### PR TITLE
added mange_service var to disable portmapper service completely

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,10 +4,12 @@
 #   include ::portmap
 #
 # @param manage_package Whether a package is needed to be installed.
+# @param manage_service Whether service is running or not.
 # @param package_name The package name, usually either `portmap` or `rpcbind`.
 # @param service_name The service name, usually either `portmap` or `rpcbind`.
 class portmap (
   Boolean          $manage_package = $::portmap::params::manage_package,
+  Boolean          $manage_service = $::portmap::params::manage_service,
   Optional[String] $package_name   = $::portmap::params::package_name,
   String           $service_name   = $::portmap::params::service_name,
 ) inherits ::portmap::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,16 +4,16 @@
 #   include ::portmap
 #
 # @param manage_package Whether a package is needed to be installed.
-# @param manage_service Whether service is running or not.
+# @param service_status The service stauts, usually either `running`, `stopped` or `mask`.
 # @param package_name The package name, usually either `portmap` or `rpcbind`.
 # @param service_name The service name, usually either `portmap` or `rpcbind`.
 # @param service_provider The service provider, usually either `init`, `systemd` or `upstart`.
 class portmap (
-  Boolean          $manage_package   = $::portmap::params::manage_package,
-  Boolean          $manage_service   = $::portmap::params::manage_service,
-  Optional[String] $package_name     = $::portmap::params::package_name,
-  String           $service_name     = $::portmap::params::service_name,
-  String           $service_provider = $::portmap::params::service_provider,
+  Boolean          $manage_package                 = $::portmap::params::manage_package,
+  Enum['mask','running','stopped'] $service_status = $::portmap::params::service_status,
+  Optional[String] $package_name                   = $::portmap::params::package_name,
+  String           $service_name                   = $::portmap::params::service_name,
+  String           $service_provider               = $::portmap::params::service_provider,
 ) inherits ::portmap::params {
 
   contain ::portmap::install

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,10 +8,11 @@
 # @param package_name The package name, usually either `portmap` or `rpcbind`.
 # @param service_name The service name, usually either `portmap` or `rpcbind`.
 class portmap (
-  Boolean          $manage_package = $::portmap::params::manage_package,
-  Boolean          $manage_service = $::portmap::params::manage_service,
-  Optional[String] $package_name   = $::portmap::params::package_name,
-  String           $service_name   = $::portmap::params::service_name,
+  Boolean          $manage_package   = $::portmap::params::manage_package,
+  Boolean          $manage_service   = $::portmap::params::manage_service,
+  Optional[String] $package_name     = $::portmap::params::package_name,
+  String           $service_name     = $::portmap::params::service_name,
+  String           $service_provider = $::portmap::params::service_provider,
 ) inherits ::portmap::params {
 
   contain ::portmap::install

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@
 # @param manage_service Whether service is running or not.
 # @param package_name The package name, usually either `portmap` or `rpcbind`.
 # @param service_name The service name, usually either `portmap` or `rpcbind`.
+# @param service_provider The service provider, usually either `init`, `systemd` or `upstart`.
 class portmap (
   Boolean          $manage_package   = $::portmap::params::manage_package,
   Boolean          $manage_service   = $::portmap::params::manage_service,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@ class portmap::params {
   case $::osfamily {
     'RedHat': {
       $manage_package = true
-      $manage_service = true
+      $service_status = 'running'
       case $::operatingsystemmajrelease {
         '5': {
           $package_name     = 'portmap'
@@ -25,7 +25,7 @@ class portmap::params {
     }
     'Debian': {
       $manage_package = true
-      $manage_service = true
+      $service_status = 'running'
       $package_name   = 'rpcbind'
       case $::lsbdistcodename {
         'precise': {
@@ -53,7 +53,7 @@ class portmap::params {
     'OpenBSD': {
       # Part of the base system
       $manage_package   = false
-      $manage_service   = false
+      $service_status   = 'stopped'
       $package_name     = undef
       $service_name     = 'portmap'
       $service_provider = 'init'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class portmap::params {
   case $::osfamily {
     'RedHat': {
       $manage_package = true
+      $manage_service = true
       case $::operatingsystemmajrelease {
         '5': {
           $package_name = 'portmap'
@@ -17,6 +18,7 @@ class portmap::params {
     }
     'Debian': {
       $manage_package = true
+      $manage_service = true
       $package_name   = 'rpcbind'
       $service_name   = $::lsbdistcodename ? {
         'precise' => 'portmap', # lolubuntu
@@ -26,6 +28,7 @@ class portmap::params {
     'OpenBSD': {
       # Part of the base system
       $manage_package = false
+      $manage_service = false
       $package_name   = undef
       $service_name   = 'portmap'
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,36 +1,61 @@
 # @!visibility private
 class portmap::params {
 
+  $manage_package = true
+  $manage_service = true
+
   case $::osfamily {
     'RedHat': {
-      $manage_package = true
-      $manage_service = true
       case $::operatingsystemmajrelease {
         '5': {
-          $package_name = 'portmap'
-          $service_name = 'portmap'
+          $package_name     = 'portmap'
+          $service_name     = 'portmap'
+          $service_provider = 'init'
+        }
+        '6': {
+          $package_name     = 'rpcbind'
+          $service_name     = 'rpcbind'
+          $service_provider = 'init'
         }
         default: {
-          $package_name = 'rpcbind'
-          $service_name = 'rpcbind'
+          $package_name     = 'rpcbind'
+          $service_name     = 'rpcbind'
+          $service_provider = 'systemd'
         }
       }
     }
     'Debian': {
-      $manage_package = true
-      $manage_service = true
       $package_name   = 'rpcbind'
-      $service_name   = $::lsbdistcodename ? {
-        'precise' => 'portmap', # lolubuntu
-        default   => 'rpcbind',
+      case $::lsbdistcodename {
+        'precise': {
+          $service_name     = 'portmap'
+          $service_provider = 'upstart'
+        }
+        'trusty': {
+          $service_name     = 'rpcbind'
+          $service_provider = 'upstart'
+        }
+        'squeeze': {
+          $service_name     = 'rpcbind'
+          $service_provider = 'init'
+        }
+        'wheezy': {
+          $service_name     = 'rpcbind'
+          $service_provider = 'init'
+        }
+        default: {
+          $service_name     = 'rpcbind'
+          $service_provider = 'systemd'
+        }
       }
     }
     'OpenBSD': {
       # Part of the base system
-      $manage_package = false
-      $manage_service = false
-      $package_name   = undef
-      $service_name   = 'portmap'
+      $manage_package   = false
+      $manage_service   = false
+      $package_name     = undef
+      $service_name     = 'portmap'
+      $service_provider = undef
     }
     default: {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,7 +56,7 @@ class portmap::params {
       $manage_service   = false
       $package_name     = undef
       $service_name     = 'portmap'
-      $service_provider = undef
+      $service_provider = 'init'
     }
     default: {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,11 +1,10 @@
 # @!visibility private
 class portmap::params {
 
-  $manage_package = true
-  $manage_service = true
-
   case $::osfamily {
     'RedHat': {
+      $manage_package = true
+      $manage_service = true
       case $::operatingsystemmajrelease {
         '5': {
           $package_name     = 'portmap'
@@ -25,6 +24,8 @@ class portmap::params {
       }
     }
     'Debian': {
+      $manage_package = true
+      $manage_service = true
       $package_name   = 'rpcbind'
       case $::lsbdistcodename {
         'precise': {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,16 +10,19 @@ class portmap::service {
     $portmap_enable  = false
   }
 
-  service {
-    "${::portmap::service_name}.service":
+  service { $::portmap::service_name:
+    ensure     => $portmap_service,
+    enable     => $portmap_enable,
+    hasstatus  => true,
+    hasrestart => true;
+  }
+
+  if $::portmap::service_provider == 'systemd' {
+    service { "${::portmap::service_name}.socket":
       ensure     => $portmap_service,
       enable     => $portmap_enable,
       hasstatus  => true,
       hasrestart => true;
-    "${::portmap::service_name}.socket":
-      ensure     => $portmap_service,
-      enable     => $portmap_enable,
-      hasstatus  => true,
-      hasrestart => true;
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,17 +1,21 @@
 # @!visibility private
 class portmap::service {
 
-  if $::portmap::manage_service {
-    $portmap_service = 'running'
-    $portmap_enable  = true
+  if $::portmap::service_status == 'running' {
+    $portmap_ensure = 'running'
+    $portmap_enable = true
+  }
+  elsif $::portmap::service_status == 'mask' {
+    $portmap_ensure = 'stopped'
+    $portmap_enable = 'mask'
   }
   else {
-    $portmap_service = 'stopped'
-    $portmap_enable  = false
+    $portmap_ensure = 'stopped'
+    $portmap_enable = false
   }
 
   service { $::portmap::service_name:
-    ensure     => $portmap_service,
+    ensure     => $portmap_ensure,
     enable     => $portmap_enable,
     hasstatus  => true,
     hasrestart => true;
@@ -19,7 +23,7 @@ class portmap::service {
 
   if $::portmap::service_provider == 'systemd' {
     service { "${::portmap::service_name}.socket":
-      ensure     => $portmap_service,
+      ensure     => $portmap_ensure,
       enable     => $portmap_enable,
       hasstatus  => true,
       hasrestart => true;

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,10 +1,25 @@
 # @!visibility private
 class portmap::service {
 
-  service { $::portmap::service_name:
-    ensure     => running,
-    enable     => true,
-    hasstatus  => true,
-    hasrestart => true,
+  if $::portmap::manage_service {
+    $portmap_service = 'running'
+    $portmap_enable  = true
+  }
+  else {
+    $portmap_service = 'stopped'
+    $portmap_enable  = false
+  }
+
+  service {
+    "${::portmap::service_name}.service":
+      ensure     => $portmap_service,
+      enable     => $portmap_enable,
+      hasstatus  => true,
+      hasrestart => true;
+    "${::portmap::service_name}.socket":
+      ensure     => $portmap_service,
+      enable     => $portmap_enable,
+      hasstatus  => true,
+      hasrestart => true;
   }
 }


### PR DESCRIPTION
fixes #1

```
  class { '::portmap':
    manage_package => false,
    service_status => 'mask',
  }
```

Will not touch package itself (prevent deinstalling with dependencies) but get sure that rpcbind is stopped and port 111 is closed.
service_status can be set to running, stopped & mask.