### PR TITLE
Drop old Puppet versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -61,7 +61,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.4.0 <6.0.0"
+      "version_requirement": ">=5.5.10 <7.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
Also bump upper bound to allow 6.x.